### PR TITLE
Testing edit task logic+documentation update tasks in user guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -8,9 +8,9 @@ ManageMe is a **desktop app for time management and resource organisation, optim
 # Table of Contents
 1. Features
     1. Tasks
-        1. Add a Task: `todo`, `event`, `deadline`
+        1. Add a Task: `addTask`
         2. Read a Task: `readTask`
-        3. Update a Task's Details: `updateTask`
+        3. Edit a Task's Details: `editTask`
         4. Delete a Task: `deleteTask`
     2. Modules
         1. Add a Module: `addMod`
@@ -39,61 +39,51 @@ ManageMe is a **desktop app for time management and resource organisation, optim
 
 **:information_source: Notes about the command format:**<br>
 
-* Words in `UPPER_CASE` are the parameters to be supplied by the user. E.g. `todo DESCRIPTION`
+* Words in `UPPER_CASE` are the parameters to be supplied by the user. E.g. `addTask n/TASK_NAME`
   , here `DESCRIPTION` is the parameter.<br>
 
-* Items in square brackets are optional. E.g. `todo DESCRIPTION [/mod CS2103]`<br>
+* Items in square brackets are optional. E.g. `addTask n/TASK_NAME [mod/CS2103]`<br>
 
 </div>
 
 --------------------------------------------------------------------------------------------------------------------
 ### TASK:
 
-#### Adding a task: `todo`, `deadline`, `event`
+#### Adding a task: `addTask`
 
-Adds a task to the address book. The task must be one of the three categories:
-
-1. `todo`: A task not associated with a date or time
-2. `deadline`: A task that must be done before a deadline
-3. `event`: A task that takes place over a time window
-
-Optionally, a task can be linked to a module.
+Adds a task to the address book.
+A name and description for the task is compulsory.
+It is optional to include an associated Module name, a start datetime and an end datetime.
+**:information_source: A start datetime cannot be included without an end datetime:**
 
 Format:
 
-    todo DESCRIPTION [/mod MODULE]
-    deadline DESCRIPTION /by DATE TIME [/mod MODULE]
-    event DESCRIPTION /at DATE START_TIME END_TIME [/mod MODULE]
+    addTask n/NAME d/DESCRIPTION [mod/MODULE_NAME] [s/START_DATETIME] [e/END_DATETIME]
 
 #### Read details of a task: `readTask`
 View a task in detail.
 
 Format: `readTask INDEX`
-- Read task details at the specified `INDEX`. The index refers to the index number shown in the displayed task list. The index **must be a positive integer** 1, 2, 3, ...
-- Tasks will be displayed in this format: [type][status] description (date time)
-    - Type: T for `todo`, D for `deadline`, E for `event`
+- Read task details at the specified `INDEX`. The index refers to the index number shown in the displayed task list. 
+- The index **must be a positive integer** 1, 2, 3, ...
+- Tasks will be displayed in this format: [Status] description (Module)(Date Time)
     - Status: X for done, blank for not done
+    - Module is the name of the associated module
     - Date is in the format: Month Day Year
     - Time is in 24-hour format
 
 Example: `readTask 3`
 
-#### Update a task: updateTask
-Update an existing task in the task list.
+#### Edit a task: editTask
+Edit an existing task in the task list.
 
-Format: `updateTask INDEX CATEGORY CONTENT`
-- Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed task list. The index **must be a positive integer** 1, 2, 3, ...
-- `CATEGORY` must be one of the following:
-    - `description`
-    - `date`
-    - `time`
-    - `start_time`
-    - `end_time`
-    - `mod`
-- The format of the `CONTENT` must match the `CATEGORY`. E.g. if `CATEGORY` is the `date`, the `CONTENT` must be a valid date like 2021-09-08
-- Existing values will be updated to the input values
+Format: `editTask INDEX [n/NAME] [d/DESCRIPTION] [mod/MODULE_NAME] [s/START_DATETIME] [e/END_DATETIME]`
+* The index refers to the index number shown in the displayed module list
+* The index **must be a positive integer** 1, 2, 3, ...
+* At least one of the optional fields must be provided.
+* Existing values will be updated to the input values.
 
-Example: `updateTask 3 description buy milk`
+Example: `editTask 3 d/buy milk`
 
 #### Deleting a task: `deleteTask`
 Deletes the specified task from the task list.
@@ -124,7 +114,7 @@ Format: `readMod INDEX`<br/>
 Examples: `readMod 2`
 
 #### Update a module: `editMod`
-Update an existing module in the address app.
+Update an existing module in the mod list.
 
 Format: `editMod INDEX [n/NAME] [l/LINK]`
 * Deletes the mod by the specified `INDEX`.<br/>
@@ -173,9 +163,9 @@ Data is saved in the hard disk automatically after any command that changes the 
 
 Action | Format, Examples
 --------|------------------
-**AddTask** | `todo DESCRIPTION [/mod MODULE]`<br>`deadline DESCRIPTION /by DATE TIME [/mod MODULE]`<br>`event DESCRIPTION /at DATE START_TIME END_TIME [/mod MODULE]` <br>e.g., `todo borrow a book /mod CS2103`<br>`deadline submit report /by 2021-08-09 14:00 /mod CS2103`<br>`event tutorial /at 2021-08-09 14:00 16:00`
+**AddTask** | `addTask n/NAME d/DESCRIPTION [mod/MODULE_NAME] [s/START_DATETIME] [e/END_DATETIME]` e.g., `addTask n/Do Assignment d/Refer to Lectures 7-9 /mod CS2100 s/2021-10-05T12:00 e/2021-10-07T23:59`
 **ReadTask** | `readTask INDEX`<br>e.g., `readTask 3`
-**UpdateTask** | `updateTask INDEX CATEGORY CONTENT`<br>e.g., `update 3 description buy milk`
+**EditTask** | `editTask INDEX [n/NAME] [d/DESCRIPTION] [mod/MODULE_NAME] [s/START_DATETIME] [e/END_DATETIME]`<br>e.g., `editTask 3 d/buy milk`
 **DeleteTask** | `deleteTask INDEX`<br>e.g., `deleteTask 3`
 **AddModule** | `addMod NAME /l LINK_NAME LINK`<br>e.g.,`addMod CS2103 /l tutorial https://...`
 **ReadModule** | `readMod INDEX`<br>e.g., `readMod 2`

--- a/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
@@ -11,7 +11,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.task.Task;

--- a/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/EditTaskCommand.java
@@ -60,7 +60,7 @@ public class EditTaskCommand extends Command {
         List<Task> lastShownList = model.getFilteredTaskList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
         Task taskToEdit = lastShownList.get(index.getZeroBased());
@@ -103,7 +103,7 @@ public class EditTaskCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof EditCommand)) {
+        if (!(other instanceof EditTaskCommand)) {
             return false;
         }
 

--- a/src/main/java/seedu/address/model/task/TaskNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/TaskNameContainsKeywordsPredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.task;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Task}'s {@code Name} matches any of the keywords given.
+ */
+public class TaskNameContainsKeywordsPredicate implements Predicate<Task> {
+    private final List<String> keywords;
+
+    public TaskNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Task task) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getName().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TaskNameContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TaskNameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/task/EditTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/EditTaskCommandTest.java
@@ -1,0 +1,165 @@
+package seedu.address.logic.commands.task;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.DESC_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.DESC_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_DESCRIPTION_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_MODULE_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_NAME_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.showTaskAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.EditTaskDescriptorBuilder;
+import seedu.address.testutil.TaskBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditTaskCommand.
+ */
+public class EditTaskCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Task editedTask = new TaskBuilder().build();
+        EditTaskCommand.EditTaskDescriptor descriptor =
+                new EditTaskDescriptorBuilder(editedTask).build();
+        EditTaskCommand editCommand = new EditTaskCommand(INDEX_FIRST, descriptor);
+
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, editedTask);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setTask(model.getFilteredTaskList().get(0), editedTask);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastTask = Index.fromOneBased(model.getFilteredTaskList().size());
+        Task lastTask = model.getFilteredTaskList().get(indexLastTask.getZeroBased());
+
+        TaskBuilder taskInList = new TaskBuilder(lastTask);
+        Task editedTask = taskInList.withName(VALID_NAME_B).withDescription(VALID_DESCRIPTION_B)
+                .withModule(VALID_MODULE_B).build();
+
+        EditTaskCommand.EditTaskDescriptor descriptor =
+                new EditTaskDescriptorBuilder().withName(VALID_NAME_B)
+                .withDescription(VALID_DESCRIPTION_B).withModule(VALID_MODULE_B).build();
+        EditTaskCommand editCommand = new EditTaskCommand(indexLastTask, descriptor);
+
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, editedTask);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setTask(lastTask, editedTask);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditTaskCommand editCommand = new EditTaskCommand(INDEX_FIRST,
+                new EditTaskCommand.EditTaskDescriptor());
+        Task editedTask = model.getFilteredTaskList().get(INDEX_FIRST.getZeroBased());
+
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, editedTask);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void execute_filteredList_success() {
+        showTaskAtIndex(model, INDEX_FIRST);
+
+        Task taskInFilteredList = model.getFilteredTaskList().get(INDEX_FIRST.getZeroBased());
+        Task editedTask = new TaskBuilder(taskInFilteredList).withName(VALID_NAME_B).build();
+        EditTaskCommand editCommand = new EditTaskCommand(INDEX_FIRST,
+                new EditTaskDescriptorBuilder().withName(VALID_NAME_B).build());
+
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, editedTask);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setTask(model.getFilteredTaskList().get(0), editedTask);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateTaskUnfilteredList_failure() {
+        Task firstTask = model.getFilteredTaskList().get(INDEX_FIRST.getZeroBased());
+        EditTaskCommand.EditTaskDescriptor descriptor =
+                new EditTaskDescriptorBuilder(firstTask).build();
+        EditTaskCommand editCommand = new EditTaskCommand(INDEX_SECOND, descriptor);
+
+        assertCommandFailure(editCommand, model, EditTaskCommand.MESSAGE_DUPLICATE_TASK);
+    }
+
+    @Test
+    public void execute_invalidTaskIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        EditTaskCommand.EditTaskDescriptor descriptor =
+                new EditTaskDescriptorBuilder().withName(VALID_NAME_B).build();
+        EditTaskCommand editCommand = new EditTaskCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidTaskIndexFilteredList_failure() {
+        showTaskAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getTaskList().size());
+
+        EditTaskCommand editCommand = new EditTaskCommand(outOfBoundIndex,
+                new EditTaskDescriptorBuilder().withName(VALID_NAME_B).build());
+
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditTaskCommand standardCommand = new EditTaskCommand(INDEX_FIRST, DESC_A);
+
+        // same values -> returns true
+        EditTaskCommand.EditTaskDescriptor copyDescriptor = new EditTaskCommand.EditTaskDescriptor(DESC_A);
+        EditTaskCommand commandWithSameValues = new EditTaskCommand(INDEX_FIRST, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditTaskCommand(INDEX_SECOND, DESC_A)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditTaskCommand(INDEX_FIRST, DESC_B)));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/task/EditTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/EditTaskCommandParserTest.java
@@ -1,0 +1,178 @@
+package seedu.address.logic.parser.task;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.DESCRIPTION_DESC_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.DESCRIPTION_DESC_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.END_DESC_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.MODULE_DESC_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.MODULE_DESC_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.NAME_DESC_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.NAME_DESC_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.START_DESC_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_DESCRIPTION_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_DESCRIPTION_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_END_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_MODULE_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_MODULE_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_NAME_A;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_NAME_B;
+import static seedu.address.logic.commands.task.TaskCommandTestUtil.VALID_START_A;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.task.EditTaskCommand;
+import seedu.address.model.task.TaskName;
+import seedu.address.testutil.EditTaskDescriptorBuilder;
+
+
+public class EditTaskCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTaskCommand.MESSAGE_USAGE);
+
+    private EditTaskCommandParser parser = new EditTaskCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_NAME_A, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", EditTaskCommand.MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + NAME_DESC_A, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + NAME_DESC_A, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC, TaskName.MESSAGE_CONSTRAINTS); // invalid name
+
+
+        // valid name followed by invalid name. The test case for invalid name followed by valid name
+        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
+        assertParseFailure(parser, "1" + NAME_DESC_B + INVALID_NAME_DESC, TaskName.MESSAGE_CONSTRAINTS);
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC + DESCRIPTION_DESC_A + MODULE_DESC_A,
+                TaskName.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND;
+        String userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_A
+                + MODULE_DESC_A + NAME_DESC_B + START_DESC_A + END_DESC_A;
+
+        EditTaskCommand.EditTaskDescriptor descriptor =
+                new EditTaskDescriptorBuilder().withName(VALID_NAME_B)
+                .withDescription(VALID_DESCRIPTION_A).withModule(VALID_MODULE_A).withStartDateTime(VALID_START_A)
+                .withEndDateTime(VALID_END_A).build();
+        EditTaskCommand expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST;
+        String userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_B + NAME_DESC_A;
+
+        EditTaskCommand.EditTaskDescriptor descriptor =
+                new EditTaskDescriptorBuilder().withDescription(VALID_DESCRIPTION_B)
+                .withName(VALID_NAME_A).build();
+        EditTaskCommand expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // name
+        Index targetIndex = INDEX_THIRD;
+        String userInput = targetIndex.getOneBased() + NAME_DESC_A;
+        EditTaskCommand.EditTaskDescriptor descriptor =
+                new EditTaskDescriptorBuilder().withName(VALID_NAME_A).build();
+        EditTaskCommand expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // description
+        userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_A;
+        descriptor = new EditTaskDescriptorBuilder().withDescription(VALID_DESCRIPTION_A).build();
+        expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // module
+        userInput = targetIndex.getOneBased() + MODULE_DESC_A;
+        descriptor = new EditTaskDescriptorBuilder().withModule(VALID_MODULE_A).build();
+        expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // start
+        userInput = targetIndex.getOneBased() + START_DESC_A;
+        descriptor = new EditTaskDescriptorBuilder().withStartDateTime(VALID_START_A).build();
+        expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // end
+        userInput = targetIndex.getOneBased() + END_DESC_A;
+        descriptor = new EditTaskDescriptorBuilder().withEndDateTime(VALID_END_A).build();
+        expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() {
+        Index targetIndex = INDEX_FIRST;
+        String userInput = targetIndex.getOneBased() + NAME_DESC_A + DESCRIPTION_DESC_A + MODULE_DESC_A
+                + START_DESC_A + END_DESC_A
+                + DESCRIPTION_DESC_B + NAME_DESC_B + MODULE_DESC_B;
+
+        EditTaskCommand.EditTaskDescriptor descriptor = new EditTaskDescriptorBuilder().withName(VALID_NAME_B)
+                .withDescription(VALID_DESCRIPTION_B).withModule(VALID_MODULE_B)
+                .withStartDateTime(VALID_START_A).withEndDateTime(VALID_END_A).build();
+        EditTaskCommand expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidValueFollowedByValidValue_success() {
+        // no other valid values specified
+        Index targetIndex = INDEX_FIRST;
+        String userInput = targetIndex.getOneBased() + INVALID_NAME_DESC + NAME_DESC_B;
+        EditTaskCommand.EditTaskDescriptor descriptor =
+                new EditTaskDescriptorBuilder().withName(VALID_NAME_B).build();
+        EditTaskCommand expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // other valid values specified
+        userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_B + INVALID_NAME_DESC + MODULE_DESC_B
+                + NAME_DESC_B;
+        descriptor =
+                new EditTaskDescriptorBuilder().withName(VALID_NAME_B).withDescription(VALID_DESCRIPTION_B)
+                .withModule(VALID_MODULE_B).build();
+        expectedCommand = new EditTaskCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/testutil/EditTaskDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditTaskDescriptorBuilder.java
@@ -1,0 +1,80 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.task.EditTaskCommand;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.TaskDescription;
+import seedu.address.model.task.TaskModule;
+import seedu.address.model.task.TaskName;
+import seedu.address.model.task.TaskTime;
+
+/**
+ * A utility class to help with building EditTaskDescriptor objects.
+ */
+public class EditTaskDescriptorBuilder {
+    private EditTaskCommand.EditTaskDescriptor descriptor;
+
+    public EditTaskDescriptorBuilder() {
+        descriptor = new EditTaskCommand.EditTaskDescriptor();
+    }
+
+    public EditTaskDescriptorBuilder(EditTaskCommand.EditTaskDescriptor descriptor) {
+        this.descriptor = new EditTaskCommand.EditTaskDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditTaskDescriptor} with fields containing {@code task}'s details
+     */
+    public EditTaskDescriptorBuilder(Task task) {
+        descriptor = new EditTaskCommand.EditTaskDescriptor();
+        descriptor.setName(task.getName());
+        descriptor.setDescription(task.getDescription());
+        descriptor.setModule(task.getTaskModule());
+        descriptor.setStart(task.getStart());
+        descriptor.setEnd(task.getEnd());
+    }
+
+
+    /**
+     * Sets the {@code TaskName} of the {@code EditTaskDescriptor} that we are building.
+     */
+    public EditTaskDescriptorBuilder withName(String name) {
+        descriptor.setName(new TaskName(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code TaskDescription} of the {@code EditTaskDescriptor} that we are building.
+     */
+    public EditTaskDescriptorBuilder withDescription(String description) {
+        descriptor.setDescription(new TaskDescription(description));
+        return this;
+    }
+
+    /**
+     * Sets the {@code TaskModule} of the {@code EditTaskDescriptor} that we are building.
+     */
+    public EditTaskDescriptorBuilder withModule(String module) {
+        descriptor.setModule(new TaskModule(module));
+        return this;
+    }
+
+    /**
+     * Sets the {@code start} of the {@code EditTaskDescriptor} that we are building.
+     */
+    public EditTaskDescriptorBuilder withStartDateTime(String start) {
+        descriptor.setStart(new TaskTime(start));
+        return this;
+    }
+
+    /**
+     * Sets the {@code end} of the {@code EditTaskDescriptor} that we are building.
+     */
+    public EditTaskDescriptorBuilder withEndDateTime(String end) {
+        descriptor.setEnd(new TaskTime(end));
+        return this;
+    }
+
+    public EditTaskCommand.EditTaskDescriptor build() {
+        return descriptor;
+    }
+}


### PR DESCRIPTION
Test:
- EditTaskCommand
- EditTaskCommandParser

Bugs found:
EditTaskCommand equals() function was comparing with EditCommand and not EditTaskCommand
EditTaskCommand was showing the wrong message for INVALID_INDEX error. Instead of MESSAGE_INVALID_TASK_DISPLAYED_INDEX it showed MESSAGE_INVALID_PERSON_DISPLAYED_INDEX