### PR TITLE
Fixeditdeletemodbug

### DIFF
--- a/src/main/java/manageme/logic/commands/module/DeleteModuleCommand.java
+++ b/src/main/java/manageme/logic/commands/module/DeleteModuleCommand.java
@@ -10,7 +10,11 @@ import manageme.logic.commands.Command;
 import manageme.logic.commands.CommandResult;
 import manageme.logic.commands.exceptions.CommandException;
 import manageme.model.Model;
+import manageme.model.link.Link;
+import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
+import manageme.model.task.Task;
+import manageme.model.task.TaskModule;
 
 /**
  * Deletes a module identified using it's displayed index from the task manager.
@@ -41,7 +45,11 @@ public class DeleteModuleCommand extends Command {
         }
 
         Module moduleToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        model.editModuleInTasksWithModule(moduleToDelete, TaskModule.empty());
+        model.editModuleInLinksWithModule(moduleToDelete, LinkModule.empty());
         model.deleteModule(moduleToDelete);
+
         return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, moduleToDelete));
     }
 

--- a/src/main/java/manageme/logic/commands/module/DeleteModuleCommand.java
+++ b/src/main/java/manageme/logic/commands/module/DeleteModuleCommand.java
@@ -10,10 +10,8 @@ import manageme.logic.commands.Command;
 import manageme.logic.commands.CommandResult;
 import manageme.logic.commands.exceptions.CommandException;
 import manageme.model.Model;
-import manageme.model.link.Link;
 import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
-import manageme.model.task.Task;
 import manageme.model.task.TaskModule;
 
 /**

--- a/src/main/java/manageme/logic/commands/module/EditModuleCommand.java
+++ b/src/main/java/manageme/logic/commands/module/EditModuleCommand.java
@@ -14,11 +14,9 @@ import manageme.logic.commands.Command;
 import manageme.logic.commands.CommandResult;
 import manageme.logic.commands.exceptions.CommandException;
 import manageme.model.Model;
-import manageme.model.link.Link;
 import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
 import manageme.model.module.ModuleName;
-import manageme.model.task.Task;
 import manageme.model.task.TaskModule;
 
 /**

--- a/src/main/java/manageme/logic/commands/module/EditModuleCommand.java
+++ b/src/main/java/manageme/logic/commands/module/EditModuleCommand.java
@@ -14,8 +14,12 @@ import manageme.logic.commands.Command;
 import manageme.logic.commands.CommandResult;
 import manageme.logic.commands.exceptions.CommandException;
 import manageme.model.Model;
+import manageme.model.link.Link;
+import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
 import manageme.model.module.ModuleName;
+import manageme.model.task.Task;
+import manageme.model.task.TaskModule;
 
 /**
  * Edits the details of an existing module in the app.
@@ -64,6 +68,8 @@ public class EditModuleCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
         }
 
+        model.editModuleInTasksWithModule(moduleToEdit, new TaskModule(editedModule.getModuleName().value));
+        model.editModuleInLinksWithModule(moduleToEdit, new LinkModule(editedModule.getModuleName().value));
         model.setModule(moduleToEdit, editedModule);
         model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
         return new CommandResult(String.format(MESSAGE_EDIT_MODULE_SUCCESS, editedModule));

--- a/src/main/java/manageme/model/Model.java
+++ b/src/main/java/manageme/model/Model.java
@@ -11,6 +11,7 @@ import manageme.model.link.Link;
 import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
 import manageme.model.task.Task;
+import manageme.model.task.TaskModule;
 
 /**
  * The API of the Model component.
@@ -93,6 +94,12 @@ public interface Model {
      */
     void setLink(Link target, Link editedLink);
 
+    /**
+     * Replaces the module in tasks with modules matching the {@code target} with {@code newTaskModule}.
+     * {@code target} must exist in the ManageMe.
+     */
+    void editModuleInLinksWithModule(Module target, LinkModule newLinkModule);
+
     /** Returns an unmodifiable view of the filtered link list */
     ObservableList<Link> getFilteredLinkList();
 
@@ -168,6 +175,12 @@ public interface Model {
      * The task identity of {@code editedtask} must not be the same as another existing task in the ManageMe.
      */
     void setTask(Task target, Task editedTask);
+
+    /**
+     * Replaces the module in tasks with modules matching the {@code target} with {@code newTaskModule}.
+     * {@code target} must exist in the ManageMe.
+     */
+    void editModuleInTasksWithModule(Module target, TaskModule newTaskModule);
 
     /** Returns an unmodifiable view of the filtered task list */
     ObservableList<Task> getFilteredTaskList();

--- a/src/main/java/manageme/model/ModelManager.java
+++ b/src/main/java/manageme/model/ModelManager.java
@@ -18,6 +18,7 @@ import manageme.model.link.Link;
 import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
 import manageme.model.task.Task;
+import manageme.model.task.TaskModule;
 
 /**
  * Represents the in-memory model of the ManageMe data.
@@ -139,6 +140,18 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void editModuleInLinksWithModule(Module target, LinkModule newLinkModule) {
+        LinkModule targetLinkModule = new LinkModule(target.getModuleName().value);
+        for (Link link: filteredLinks) {
+            if (link.getLinkModule().equals(targetLinkModule)) {
+                Link sameLinkEditedModule = new Link(link.getName(), link.getAddress(),
+                        newLinkModule);
+                setLink(link, sameLinkEditedModule);
+            }
+        }
+    }
+
+    @Override
     public boolean hasModule(Module module) {
         requireNonNull(module);
         return manageMe.hasModule(module);
@@ -158,7 +171,6 @@ public class ModelManager implements Model {
     @Override
     public void setModule(Module target, Module editedModule) {
         CollectionUtil.requireAllNonNull(target, editedModule);
-
         manageMe.setModule(target, editedModule);
     }
 
@@ -184,6 +196,18 @@ public class ModelManager implements Model {
         CollectionUtil.requireAllNonNull(target, editedTask);
 
         manageMe.setTask(target, editedTask);
+    }
+
+    @Override
+    public void editModuleInTasksWithModule(Module target, TaskModule newTaskModule) {
+        TaskModule targetTaskModule = new TaskModule(target.getModuleName().value);
+        for (Task task: filteredTasks) {
+            if (task.getTaskModule().equals(targetTaskModule)) {
+                Task sameTaskEditedModule = new Task(task.getName(), task.getDescription(), task.isDone(),
+                        newTaskModule, task.getStart(), task.getEnd());
+                setTask(task, sameTaskEditedModule);
+            }
+        }
     }
 
     /**

--- a/src/main/java/manageme/model/link/LinkModule.java
+++ b/src/main/java/manageme/model/link/LinkModule.java
@@ -7,12 +7,16 @@ import java.util.Optional;
 
 
 public class LinkModule {
-    public static final String MESSAGE_CONSTRAINTS = "Modules should only contain alphanumeric characters";
+    public static final String MESSAGE_CONSTRAINTS = "Modules should only contain alphanumeric characters "
+            + "and whitespaces";
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    //public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+
+    //This allows whitespace in between characters
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String value;
     public final Optional<String> moduleName;

--- a/src/main/java/manageme/model/task/TaskModule.java
+++ b/src/main/java/manageme/model/task/TaskModule.java
@@ -7,12 +7,13 @@ import java.util.Optional;
 
 
 public class TaskModule {
-    public static final String MESSAGE_CONSTRAINTS = "Modules should only contain alphanumeric characters";
+    public static final String MESSAGE_CONSTRAINTS = "Modules should only contain alphanumeric characters "
+            + "and whitespaces";
 
     //This does not allow any whitespace in between characters
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    //public static final String VALIDATION_REGEX = "\\p{Alnum}+";
     //This allows whitespace in between characters
-    //public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String value;
     public final Optional<String> moduleName;

--- a/src/main/java/manageme/model/task/UniqueTaskList.java
+++ b/src/main/java/manageme/model/task/UniqueTaskList.java
@@ -10,6 +10,7 @@ import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import manageme.commons.util.CollectionUtil;
+import manageme.model.module.Module;
 import manageme.model.task.exceptions.DuplicateTaskException;
 import manageme.model.task.exceptions.TaskNotFoundException;
 

--- a/src/main/java/manageme/model/task/UniqueTaskList.java
+++ b/src/main/java/manageme/model/task/UniqueTaskList.java
@@ -10,7 +10,6 @@ import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import manageme.commons.util.CollectionUtil;
-import manageme.model.module.Module;
 import manageme.model.task.exceptions.DuplicateTaskException;
 import manageme.model.task.exceptions.TaskNotFoundException;
 

--- a/src/test/java/manageme/logic/commands/link/AddLinkCommandTest.java
+++ b/src/test/java/manageme/logic/commands/link/AddLinkCommandTest.java
@@ -27,6 +27,7 @@ import manageme.model.link.Link;
 import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
 import manageme.model.task.Task;
+import manageme.model.task.TaskModule;
 import manageme.testutil.LinkBuilder;
 
 public class AddLinkCommandTest {
@@ -146,6 +147,11 @@ public class AddLinkCommandTest {
         }
 
         @Override
+        public void editModuleInLinksWithModule(Module target, LinkModule newLinkModule) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void openLink(Link target) {
             throw new AssertionError("This method should not be called.");
         }
@@ -222,6 +228,11 @@ public class AddLinkCommandTest {
 
         @Override
         public void setTask(Task target, Task editedTask) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void editModuleInTasksWithModule(Module target, TaskModule newTaskModule) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/manageme/logic/commands/module/AddModuleCommandTest.java
+++ b/src/test/java/manageme/logic/commands/module/AddModuleCommandTest.java
@@ -30,6 +30,7 @@ import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
 import manageme.model.module.ModuleName;
 import manageme.model.task.Task;
+import manageme.model.task.TaskModule;
 import manageme.testutil.ModuleBuilder;
 
 public class AddModuleCommandTest {
@@ -150,6 +151,11 @@ public class AddModuleCommandTest {
         }
 
         @Override
+        public void editModuleInLinksWithModule(Module target, LinkModule newLinkModule) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void openLink(Link target) {
             throw new AssertionError("This method should not be called.");
         }
@@ -226,6 +232,11 @@ public class AddModuleCommandTest {
 
         @Override
         public void setTask(Task target, Task editedTask) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void editModuleInTasksWithModule(Module target, TaskModule newTaskModule) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/manageme/logic/commands/module/DeleteModuleCommandTest.java
+++ b/src/test/java/manageme/logic/commands/module/DeleteModuleCommandTest.java
@@ -15,7 +15,9 @@ import manageme.commons.core.index.Index;
 import manageme.model.Model;
 import manageme.model.ModelManager;
 import manageme.model.UserPrefs;
+import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
+import manageme.model.task.TaskModule;
 
 public class DeleteModuleCommandTest {
     private Model model = new ModelManager(getTypicalManageMe(), new UserPrefs());
@@ -29,6 +31,8 @@ public class DeleteModuleCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getManageMe(), new UserPrefs());
         expectedModel.deleteModule(moduleToDelete);
+        expectedModel.editModuleInTasksWithModule(moduleToDelete, TaskModule.empty());
+        expectedModel.editModuleInLinksWithModule(moduleToDelete, LinkModule.empty());
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/manageme/logic/commands/task/AddTaskCommandTest.java
+++ b/src/test/java/manageme/logic/commands/task/AddTaskCommandTest.java
@@ -27,6 +27,7 @@ import manageme.model.link.Link;
 import manageme.model.link.LinkModule;
 import manageme.model.module.Module;
 import manageme.model.task.Task;
+import manageme.model.task.TaskModule;
 import manageme.testutil.TaskBuilder;
 
 public class AddTaskCommandTest {
@@ -146,6 +147,11 @@ public class AddTaskCommandTest {
         }
 
         @Override
+        public void editModuleInLinksWithModule(Module target, LinkModule newLinkModule) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void openLink(Link target) {
             throw new AssertionError("This method should not be called.");
         }
@@ -182,6 +188,11 @@ public class AddTaskCommandTest {
 
         @Override
         public void setModule(Module target, Module editedModule) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void editModuleInTasksWithModule(Module target, TaskModule newTaskModule) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
- fixed a bug where you could edit/delete a mod and the task/link would still reflect the old mod
- if you edit a module name now, the associated task/link's module name will also change
- if you delete a module name now, the associated task/link's module name will be reset back to blank

Closes #221 
Closes #222 